### PR TITLE
Switch to Guzzle 3.7+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ]
   , "require": {
         "php": ">=5.3.2"
-      , "guzzle/guzzle": "~3.2.0"
+      , "guzzle/guzzle": "~3.7.0"
     }
   , "autoload": {
         "psr-0": {

--- a/tests/OAuth2/Tests/ClientTest.php
+++ b/tests/OAuth2/Tests/ClientTest.php
@@ -91,7 +91,10 @@ class ClientTest extends \OAuth2\Tests\TestCase
     $response = $this->client->request('GET', '/success');
     $this->assertEquals('yay', $response->body());
     $this->assertEquals(200, $response->status());
-    $this->assertEquals(array('Content-Type' => array('text/awesome')), $response->headers());
+    $headers = $response->headers();
+    $this->assertCount(1, $headers);
+    $this->assertArrayHasKey('content-type', $headers);
+    $this->assertEquals(array('text/awesome'), $headers['content-type']->toArray());
 
     // posts a body
     $response = $this->client->request('POST', '/reflect', array('body' => 'foo=bar'));
@@ -101,7 +104,10 @@ class ClientTest extends \OAuth2\Tests\TestCase
     $response = $this->client->request('GET', '/redirect');
     $this->assertEquals('yay', $response->body());
     $this->assertEquals(200, $response->status());
-    $this->assertEquals(array('Content-Type' => array('text/awesome')), $response->headers());
+    $headers = $response->headers();
+    $this->assertCount(1, $headers);
+    $this->assertArrayHasKey('content-type', $headers);
+    $this->assertEquals(array('text/awesome'), $headers['content-type']->toArray());
 
     // redirects using GET on a 303
     $response = $this->client->request('POST', '/redirect', array('body' => 'foo=bar'));
@@ -119,7 +125,10 @@ class ClientTest extends \OAuth2\Tests\TestCase
     $this->client->options['raise_errors'] = false;
     $response = $this->client->request('GET', '/unauthorized');
     $this->assertEquals(401, $response->status());
-    $this->assertEquals(array('Content-Type' => array('application/json')), $response->headers());
+    $headers = $response->headers();
+    $this->assertCount(1, $headers);
+    $this->assertArrayHasKey('content-type', $headers);
+    $this->assertEquals(array('application/json'), $headers['content-type']->toArray());
     $this->assertNotNull($response->error);
 
     // test if exception are thrown when raise_errors is true
@@ -202,7 +211,8 @@ class ClientTest extends \OAuth2\Tests\TestCase
         $opts['body'] = '';
       }
       $headers = $response->headers();
-      return $this->client->request($args[0], $headers['location'][0], $opts);
+      $location = $headers['location']->toArray();
+      return $this->client->request($args[0], $location[0], $opts);
     } else if (in_array($response->status(), range(400, 599))) {
       $e = new \OAuth2\Error($response);
       if ($opts['raise_errors'] || $this->client->options['raise_errors']) {

--- a/tests/OAuth2/Tests/ResponseTest.php
+++ b/tests/OAuth2/Tests/ResponseTest.php
@@ -23,11 +23,14 @@ class ResponseTest extends \OAuth2\Tests\TestCase
 
     // returns the status, headers and body
     $this->response = new \OAuth2\Response(new \Guzzle\Http\Message\Response($status, $headers, $body));
-    $this->assertEquals($headers, $this->response->headers());
+    $responseHeaders = $this->response->headers();
+    $this->assertCount(1, $responseHeaders);
+    $this->assertArrayHasKey('foo', $responseHeaders);
+    $this->assertEquals($headers['foo'], $responseHeaders['foo']->toArray());
     $this->assertEquals($status, $this->response->status());
     $this->assertEquals($body, $this->response->body());
   }
-  
+
  /**
   * @covers OAuth2\Response::content_type()
   * @covers OAuth2\Response::parse()


### PR DESCRIPTION
You lock guzzle to 3.2.*, but I need newer version of guzzle.

I change the guzzle to 3.7+ and fix tests. It seems that everything is working. Can you also make new release? I need it for MultiPass
