### PR TITLE
Automatically add the provided client_id and client_secret

### DIFF
--- a/src/OAuth2/Client.php
+++ b/src/OAuth2/Client.php
@@ -159,6 +159,9 @@ class Client
       , 'parse' => isset($params['parse']) ? $params['parse'] : 'automatic'
     );
     unset($params['parse']);
+
+    $params['client_id'] = $this->getId();
+    $params['client_secret'] = $this->getSecret();
     
     $opts['params']  = $params;
     if ($this->options['token_method'] === 'POST') {


### PR DESCRIPTION
Automatically add the provided client_id and client_secret to the params when requesting a token.

Seems odd that if demanding client_id and client_secret in the constructor and providing get/set methods not to use that data within the lib itself. Rather than having to pass them manually like so:

```
$accessToken = $client->getToken(array(
    'client_id' => $client->getId(),
    'client_secret' => $client->getSecret(),
    'grant_type' => 'password',
    'username' => 'username',
    'password' => 'password'
));
```
