### PR TITLE
Fix issue when authenticating with Google.

### DIFF
--- a/src/OAuth2/Response.php
+++ b/src/OAuth2/Response.php
@@ -55,11 +55,17 @@ class Response
 
       case 'automatic':
       default:
-        if (in_array($this->content_type(), array('application/json', 'text/javascript'))) {
-          $parsed = json_decode($this->body(), true);
+        $types = array('application/json', 'text/javascript');
+        $content_type = $this->content_type();
+
+        foreach ($types as $type) {
+          if (stripos($content_type, $type) !== false) {
+            $parsed = json_decode($this->body(), true);
+            break;
+          }
         }
 
-        if ($this->content_type() === "application/x-www-form-urlencoded") {
+        if (stripos($content_type, "application/x-www-form-urlencoded") !== false) {
           parse_str($this->body(), $parsed);
         }
         break;


### PR DESCRIPTION
Google's HTTP reply to the authentication call included the charset in the Content-Type header ("appplication/json; charset=utf8" instead of simply "application/json"), so the simple string comparison was failing and the Response::parse() method was returning null and causing an exception in Keeguon/Multipass.
